### PR TITLE
change module type

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "graphwise-styleguide",
   "version": "0.0.1-init2",
   "license": "Apache-2.0",
+  "type": "module",
   "scripts": {
     "build": "rm -rf dist && npm run build:tokens",
     "build:tokens": "node src/index.js",

--- a/src/generate-tokens-html.js
+++ b/src/generate-tokens-html.js
@@ -1,8 +1,6 @@
-// generate-tokens-html.js
-const fs = require('fs');
-const path = require('path');
-
-const tokens = require('../tokens/tokens.json');
+import fs from 'fs';
+import path from 'path';
+import tokens from '../tokens/tokens.json' with { type: 'json' };
 
 // Recursively extract all tokens, grouped by $type
 function extractTokens(obj, prefix = [], result = {}) {


### PR DESCRIPTION
Module type changed to `module` to prevent warnings during generation. 
Updated tokens html generator to use import instead of require