### PR TITLE
Publish tokens browser docs to GitHub Pages on release

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,3 +1,10 @@
+## GitHub Pages publishing
+
+`.github/workflows/publish-tokens-docs.yml` (with helper `.github/scripts/assemble-pages-site.mjs`) publishes the
+`npm run generate` output (tokens browser + CSS variables diff) to GitHub Pages on every `vX.Y.Z` tag push, keeping a
+snapshot per version. Do not remove or break this workflow without understanding why it exists — see the "Tokens
+browser" section in README.md.
+
 When writing a pull request overview, use the following template:
 
 ## What

--- a/.github/scripts/assemble-pages-site.mjs
+++ b/.github/scripts/assemble-pages-site.mjs
@@ -6,8 +6,17 @@ const GENERATED_DIR = process.env.GENERATED_DIR || "generated";
 const PREV_SITE_DIR = process.env.PREV_SITE_DIR || "gh-pages-prev";
 const OUT_DIR = process.env.OUT_DIR || "pages-site";
 
-if (!VERSION) {
-  console.error("VERSION env var is required");
+// Restricts VERSION to a safe charset (digits, dots, alphanumeric prerelease suffix) so it
+// can't contain path separators/".." (path traversal into OUT_DIR) or HTML-meaningful
+// characters (markup injection into the published pages).
+const VERSION_PATTERN = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/;
+// Same shape, prefixed with the "v" used for version snapshot directory names.
+const VERSION_DIR_PATTERN = /^v\d+\.\d+\.\d+(?:-[0-9A-Za-z.]+)?$/;
+
+if (!VERSION || !VERSION_PATTERN.test(VERSION)) {
+  console.error(
+    `VERSION env var must be a semantic version like "1.2.3" or "1.2.3-test", got: ${JSON.stringify(VERSION)}`
+  );
   process.exit(1);
 }
 
@@ -22,7 +31,7 @@ fs.mkdirSync(OUT_DIR, { recursive: true });
 // Carry forward previously published version snapshots.
 if (fs.existsSync(PREV_SITE_DIR)) {
   for (const entry of fs.readdirSync(PREV_SITE_DIR)) {
-    if (/^v/.test(entry) && fs.statSync(path.join(PREV_SITE_DIR, entry)).isDirectory()) {
+    if (VERSION_DIR_PATTERN.test(entry) && fs.statSync(path.join(PREV_SITE_DIR, entry)).isDirectory()) {
       fs.cpSync(path.join(PREV_SITE_DIR, entry), path.join(OUT_DIR, entry), { recursive: true });
     }
   }
@@ -62,7 +71,7 @@ function landingHtml(version, isLatest) {
 function rootIndexHtml(version) {
   const versionDirs = fs
     .readdirSync(OUT_DIR)
-    .filter((entry) => /^v/.test(entry) && fs.statSync(path.join(OUT_DIR, entry)).isDirectory())
+    .filter((entry) => VERSION_DIR_PATTERN.test(entry) && fs.statSync(path.join(OUT_DIR, entry)).isDirectory())
     .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
 
   const links = PAGES.map(

--- a/.github/scripts/assemble-pages-site.mjs
+++ b/.github/scripts/assemble-pages-site.mjs
@@ -1,0 +1,124 @@
+import fs from "fs";
+import path from "path";
+
+const VERSION = process.env.VERSION;
+const GENERATED_DIR = process.env.GENERATED_DIR || "generated";
+const PREV_SITE_DIR = process.env.PREV_SITE_DIR || "gh-pages-prev";
+const OUT_DIR = process.env.OUT_DIR || "pages-site";
+
+if (!VERSION) {
+  console.error("VERSION env var is required");
+  process.exit(1);
+}
+
+const PAGES = [
+  { file: "tokens-browser.html", label: "Tokens Browser", description: "Search and filter all design tokens." },
+  { file: "css-variables-diff.html", label: "CSS Variables Diff", description: "Diff report between CSS variables." },
+];
+
+fs.rmSync(OUT_DIR, { recursive: true, force: true });
+fs.mkdirSync(OUT_DIR, { recursive: true });
+
+// Carry forward previously published version snapshots.
+if (fs.existsSync(PREV_SITE_DIR)) {
+  for (const entry of fs.readdirSync(PREV_SITE_DIR)) {
+    if (/^v/.test(entry) && fs.statSync(path.join(PREV_SITE_DIR, entry)).isDirectory()) {
+      fs.cpSync(path.join(PREV_SITE_DIR, entry), path.join(OUT_DIR, entry), { recursive: true });
+    }
+  }
+}
+
+function landingHtml(version, isLatest) {
+  const links = PAGES.map(
+    (p) => `<li><a href="${p.file}">${p.label}</a><p>${p.description}</p></li>`
+  ).join("\n      ");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Graphwise Styleguide — Design Tokens${isLatest ? "" : ` (${version})`}</title>
+<style>
+  body { font-family: sans-serif; max-width: 640px; margin: 3rem auto; padding: 0 1rem; color: #222; }
+  h1 { margin-bottom: 0; }
+  .version { color: #888; margin-top: 0.25rem; }
+  ul { list-style: none; padding: 0; }
+  li { border: 1px solid #eee; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+  li a { font-size: 1.1rem; font-weight: 600; text-decoration: none; color: #0b5fff; }
+  li p { margin: 0.4rem 0 0; color: #555; }
+</style>
+</head>
+<body>
+  <h1>Graphwise Styleguide</h1>
+  <p class="version">Design tokens — ${isLatest ? `latest (${version})` : version}</p>
+  <ul>
+      ${links}
+  </ul>
+</body>
+</html>
+`;
+}
+
+function rootIndexHtml(version) {
+  const versionDirs = fs
+    .readdirSync(OUT_DIR)
+    .filter((entry) => /^v/.test(entry) && fs.statSync(path.join(OUT_DIR, entry)).isDirectory())
+    .sort((a, b) => b.localeCompare(a, undefined, { numeric: true }));
+
+  const links = PAGES.map(
+    (p) => `<li><a href="${p.file}">${p.label}</a><p>${p.description}</p></li>`
+  ).join("\n      ");
+
+  const historyItems = versionDirs
+    .map((v) => `<li><a href="${v}/">${v}</a></li>`)
+    .join("\n      ");
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Graphwise Styleguide — Design Tokens</title>
+<style>
+  body { font-family: sans-serif; max-width: 640px; margin: 3rem auto; padding: 0 1rem; color: #222; }
+  h1 { margin-bottom: 0; }
+  .version { color: #888; margin-top: 0.25rem; }
+  ul { list-style: none; padding: 0; }
+  li { border: 1px solid #eee; border-radius: 8px; padding: 1rem; margin-bottom: 1rem; }
+  li a { font-size: 1.1rem; font-weight: 600; text-decoration: none; color: #0b5fff; }
+  li p { margin: 0.4rem 0 0; color: #555; }
+  h2 { margin-top: 2.5rem; }
+  .history { list-style: none; padding: 0; display: flex; flex-wrap: wrap; gap: 0.5rem; }
+  .history li { border: none; padding: 0; margin: 0; }
+  .history a { display: inline-block; padding: 0.35rem 0.75rem; border: 1px solid #ddd; border-radius: 6px; font-weight: 500; font-size: 0.9rem; }
+</style>
+</head>
+<body>
+  <h1>Graphwise Styleguide</h1>
+  <p class="version">Design tokens — latest (${version})</p>
+  <ul>
+      ${links}
+  </ul>
+  <h2>Version history</h2>
+  <ul class="history">
+      ${historyItems || "<li>No older versions yet.</li>"}
+  </ul>
+</body>
+</html>
+`;
+}
+
+// Latest version snapshot.
+const versionDir = path.join(OUT_DIR, `v${VERSION}`);
+fs.mkdirSync(versionDir, { recursive: true });
+for (const p of PAGES) {
+  fs.copyFileSync(path.join(GENERATED_DIR, p.file), path.join(versionDir, p.file));
+}
+fs.writeFileSync(path.join(versionDir, "index.html"), landingHtml(VERSION, false));
+
+// Root = latest version, plus the version history index.
+for (const p of PAGES) {
+  fs.copyFileSync(path.join(GENERATED_DIR, p.file), path.join(OUT_DIR, p.file));
+}
+fs.writeFileSync(path.join(OUT_DIR, "index.html"), rootIndexHtml(VERSION));
+
+console.log(`✅ Assembled Pages site at ${OUT_DIR} (version ${VERSION})`);

--- a/.github/workflows/publish-tokens-docs.yml
+++ b/.github/workflows/publish-tokens-docs.yml
@@ -1,0 +1,100 @@
+name: Publish tokens docs to GitHub Pages
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version label for a manual test run (e.g. 0.0.1-test)"
+        required: false
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22.17.0"
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Generate token docs
+        run: npm run generate
+
+      - name: Resolve version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ inputs.version }}" ]; then
+            VERSION="${{ inputs.version }}"
+          elif [ "${{ github.ref_type }}" = "tag" ]; then
+            VERSION="${GITHUB_REF_NAME#v}"
+          else
+            VERSION=$(node -p "require('./package.json').version")
+          fi
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout previous gh-pages (history)
+        uses: actions/checkout@v4
+        continue-on-error: true
+        with:
+          ref: gh-pages
+          path: gh-pages-prev
+
+      - name: Assemble Pages site
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+          GENERATED_DIR: generated
+          PREV_SITE_DIR: gh-pages-prev
+          OUT_DIR: pages-site
+        run: node .github/scripts/assemble-pages-site.mjs
+
+      - name: Persist site to gh-pages branch (history storage)
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            git fetch origin gh-pages
+            git worktree add gh-pages-branch origin/gh-pages
+          else
+            git worktree add --orphan -b gh-pages gh-pages-branch
+          fi
+
+          rsync -a --delete pages-site/ gh-pages-branch/
+
+          cd gh-pages-branch
+          git add -A
+          git commit -m "Publish tokens docs for v${{ steps.version.outputs.version }}" || echo "No changes to commit"
+          git push origin gh-pages
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: pages-site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -40,10 +40,16 @@ npm install graphwise-styleguide
 Tokens file is big and hard to read in raw json format. To make it easier to browse and understand the tokens, you can
 run the following command
 ```bash
-npm run generate-tokens-html
+npm run generate
 ```
-This will generate a `tokens-browser.html` file in the root directory of the repository. Open this file in your browser
-to view the tokens in a more user-friendly format.
+This will generate `generated/tokens-browser.html` and `generated/css-variables-diff.html`. Open either file in your
+browser to view the tokens (or the CSS variables diff report) in a more user-friendly format.
+
+A version of this tokens browser is also published automatically to GitHub Pages on every release:
+**https://ontotext-ad.github.io/graphwise-styleguide/**
+
+The published site keeps a snapshot per released version under `/vX.Y.Z/`, with the latest version always available at
+the root.
 
 ## Optimize Styleguide
 Graphwise Styleguide provides executable script `gw-purge-css`, which can be used to purge unused variables and generate


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `npm run generate` and publishes the resulting tokens browser + CSS variables diff to GitHub Pages whenever a vX.Y.Z tag is pushed (matching the existing Jenkins release flow), keeping a snapshot per version.