### PR TITLE
Run npm run build before generate in Pages workflow

### DIFF
--- a/.github/workflows/publish-tokens-docs.yml
+++ b/.github/workflows/publish-tokens-docs.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Build stylesheets
+        run: npm run build
+
       - name: Generate token docs
         run: npm run generate
 


### PR DESCRIPTION
compare-css-variables reads the local dist/ output to diff against the currently published npm package, but the workflow never produced dist/ - it only ran `npm run generate`, which fails with ENOENT on a clean checkout (it happened to work locally because a stale dist/ was already present from a previous manual build).