### PR TITLE
Avoid nested git checkout when fetching gh-pages history

### DIFF
--- a/.github/workflows/publish-tokens-docs.yml
+++ b/.github/workflows/publish-tokens-docs.yml
@@ -79,12 +79,16 @@ jobs:
 
           if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
             git fetch origin gh-pages
-            git worktree add gh-pages-branch origin/gh-pages
+            git worktree add -B gh-pages gh-pages-branch origin/gh-pages
           else
             git worktree add --orphan -b gh-pages gh-pages-branch
           fi
 
-          rsync -a --delete pages-site/ gh-pages-branch/
+          # Replace everything except the .git gitfile pointer that links the
+          # worktree to the main repo (rsync's size+mtime quick check can skip
+          # changed files, so plain remove-and-copy is used instead).
+          find gh-pages-branch -mindepth 1 -maxdepth 1 ! -name .git -exec rm -rf {} +
+          cp -r pages-site/. gh-pages-branch/
 
           cd gh-pages-branch
           git add -A

--- a/.github/workflows/publish-tokens-docs.yml
+++ b/.github/workflows/publish-tokens-docs.yml
@@ -56,12 +56,13 @@ jobs:
           fi
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
 
-      - name: Checkout previous gh-pages (history)
-        uses: actions/checkout@v4
-        continue-on-error: true
-        with:
-          ref: gh-pages
-          path: gh-pages-prev
+      - name: Fetch previous gh-pages content
+        run: |
+          mkdir -p gh-pages-prev
+          if git ls-remote --exit-code --heads origin gh-pages > /dev/null 2>&1; then
+            git fetch origin gh-pages
+            git archive origin/gh-pages | tar -x -C gh-pages-prev
+          fi
 
       - name: Assemble Pages site
         env:


### PR DESCRIPTION
actions/checkout with continue-on-error left a broken embedded .git in gh-pages-prev/ when the gh-pages branch didn't exist yet, which then made the later `git worktree add` / `git add -A` step fail with "does not have a commit checked out". Replaced it with a plain git fetch + git archive into a non-git directory, and only when the branch actually exists.